### PR TITLE
bump global.json feature band version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "3.1.201",
-    "rollForward": "latestMinor"
+    "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.100"
+    "version": "3.1.201",
+    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
our dotnet 3.1 image is now using 3.1.201, which is incompatible with this repo's global.json.